### PR TITLE
Adicionar suporte ao Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,48 @@
+tasks:
+  # Auto-restore Gitpod environment variables
+  # https://www.gitpod.io/guides/automate-env-files-with-gitpod-environment-variables
+  - name: Restore .env file
+    command: |
+      if [ -f .env ]; then
+        # If this workspace already has a .env, don't override it
+        # Local changes survive a workspace being opened and closed
+        # but they will not persist between separate workspaces for the same repo
+        echo "Found .env in workspace"
+      else
+        if [ -z "${DOTENV}" ]; then
+          # There is no $DOTENV from a previous workspace
+          # Default to the example .env
+          echo "Setting example .env"
+          cp .env.example .env 
+        else
+          # After making changes to .env, run this line to persist it to $DOTENV
+          #   gp env DOTENV="$(base64 .env | tr -d '\n')"
+          # 
+          # Environment variables set this way are shared between all your workspaces for this repo
+          # The lines below will read $DOTENV and print a .env file
+          echo "Restoring .env from Gitpod"
+          echo "${DOTENV}" | base64 -d > .env
+        fi
+      fi
+  - name: Start bot
+    init: npm install
+    command: npm run start
+
+# Gitpod suggested commands to add github support to Gitpod.
+# This should make using Gitpod easier and faster. 
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: false
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
+    addComment: true
+    # add a "Review in Gitpod" button to pull requests (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: prebuilt-in-gitpod


### PR DESCRIPTION
Foi adicionado um ficheiro base `.gitpod.yml` que identifica que ações devem ser executadas quando o setup de um novo workspace é feito (`npm install`) e sempre que este é iniciado (`npm run start`).

As ações serão executadas de forma sequencial e será iniciada uma nova instância do terminal para a sua execução.

Foi também adicionado um script com auto-recover das [variáveis de ambiente adicionadas no Gitpod](https://www.gitpod.io/guides/automate-env-files-with-gitpod-environment-variables), no entanto o comando para guardar quaisquer alterações ao ficheiro `.env` é (a ser executado dentro do container do Gitpod):
```sh
gp env DOTENV="$(base64 .env | tr -d '\n')"
```

Esta automação apenas ajuda a que qualquer ambiente seja sempre efémero e nunca mais seja necessário definir quaisquer variáveis de ambiente.

Foram também adicionadas algumas definições para uma melhor integração com o GitHub.

Pessoalmente, recomendo também a [instalação da browser extension](https://www.gitpod.io/docs/browser-extension) para permitir também esta uma melhor integração com o ecossistema do GitHub. 

Closes #27.